### PR TITLE
Fix/custom jsx array children

### DIFF
--- a/dist/bin/abdo.js
+++ b/dist/bin/abdo.js
@@ -640,6 +640,9 @@ async function getBrowser(config = {}) {
 				`--window-size=${config.windowSize[0]},${config.windowSize[1]}`,
 				'--incognito',
 				`--ignore-certificate-errors-spki-list=${fingerprint}`,
+				'--disable-web-security',
+				'--disable-features=IsolateOrigins',
+				'--disable-site-isolation-trials',
 			].concat(config.browserArgs || []),
 		});
 

--- a/dist/lib/pptr-toolbar.js
+++ b/dist/lib/pptr-toolbar.js
@@ -18,6 +18,7 @@
 	const isArray = (arr) => Array.isArray(arr);
 	const isObject = (obj) => obj && typeof obj === "object";
 	const createDocumentFragment = () => document.createDocumentFragment();
+	const isDomFragment = (node) => node && node.nodeType === 11;
 	const getVNodeDom = (vnode, recursive) => vnode ? vnode.__dom || (recursive ? getVNodeDom(vnode.__result) : vnode.__result?.__dom) : null;
 	const getVNodeFirstRenderedDom = (vnode) => {
 	  if (!vnode)
@@ -255,7 +256,7 @@
 	};
 	const patchVnodeDom = (vnode, prevVnode, targetDomNode, afterNode) => {
 	  let prepend = false;
-	  if (prevVnode) {
+	  if ((!targetDomNode || isDomFragment(targetDomNode)) && prevVnode) {
 	    const someDom = getVNodeFirstRenderedDom(prevVnode);
 	    if (someDom) {
 	      targetDomNode = getParent(someDom);
@@ -295,7 +296,7 @@
 	    const oldChildVnode = oldChildren && (child && oldChildrenMap.get(child.key) || oldChildren[index]);
 	    const patchedDomNode = patchVnodeDom(child, (!child || isVnodeSame) && oldChildVnode, returnDom, prevNode);
 	    if (isRenderableElement(patchedDomNode)) {
-	      prevNode = patchedDomNode.nodeType === 11 ? patchedDomNode.lastChild : patchedDomNode;
+	      prevNode = isDomFragment(patchedDomNode) ? patchedDomNode.lastChild : patchedDomNode;
 	    }
 	  }
 	  if (isRenderableElement(returnDom)) {
@@ -421,7 +422,7 @@
 	    return child;
 	  if (!child)
 	    return [];
-	  return child.nodeType === 11 ? Array.from(child.children) : [child];
+	  return isDomFragment(child) ? Array.from(child.children) : [child];
 	};
 	const clearPrevious = (child, parent) => {
 	  const children = getChildrenArray(child);

--- a/lib/plugins/custom-prefresh-utils.js
+++ b/lib/plugins/custom-prefresh-utils.js
@@ -99,25 +99,23 @@ function replaceComponent(OldType, NewType, resetHookState) {
 			}
 		}
 		// Functional
-		else {
-			if (resetHookState) {
-				vnode.__hooks = [];
-			} else if (vnode.__hooks?.length) {
-				vnode.__hooks.forEach((effect) => {
-					if (Array.isArray(effect) && effect.length) {
-						// Run possible cleanup functions
-						if (effect[0] === 'e') {
-							if (typeof effect[2] === 'function') {
-								effect[2]();
-							}
-							// Reset hook dependencies so it would run again on next render
-							if (Array.isArray(effect[1])) {
-								effect[1] = undefined;
-							}
+		else if (resetHookState) {
+			vnode.__hooks = [];
+		} else if (vnode.__hooks?.length) {
+			vnode.__hooks.forEach((effect) => {
+				if (Array.isArray(effect) && effect.length) {
+					// Run possible cleanup functions
+					if (effect[0] === 'e') {
+						if (typeof effect[2] === 'function') {
+							effect[2]();
+						}
+						// Reset hook dependencies so it would run again on next render
+						if (Array.isArray(effect[1])) {
+							effect[1] = undefined;
 						}
 					}
-				});
-			}
+				}
+			});
 		}
 
 		const oldVnode = { ...vnode };

--- a/lib/puppeteer.js
+++ b/lib/puppeteer.js
@@ -361,6 +361,9 @@ export async function getBrowser(config = {}) {
 				`--window-size=${config.windowSize[0]},${config.windowSize[1]}`,
 				'--incognito',
 				`--ignore-certificate-errors-spki-list=${fingerprint}`,
+				'--disable-web-security',
+				'--disable-features=IsolateOrigins',
+				'--disable-site-isolation-trials',
 			].concat(config.browserArgs || []),
 		});
 

--- a/src/jsx.js
+++ b/src/jsx.js
@@ -29,7 +29,7 @@ const createElement = (tag, props, ...children) => {
 		}
 	}
 
-	if (children) props.children = children;
+	props.children = children;
 
 	const vnode = createVNode(tag, props);
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -8,6 +8,7 @@ import {
 	domRemove,
 	getVNodeDom,
 	isArray,
+	isDomFragment,
 } from './internal';
 
 export const createSelector = (node, selector) => [node, selector];
@@ -134,7 +135,7 @@ const getChildrenArray = (child) => {
 	if (isArray(child)) return child;
 	if (!child) return [];
 	// If document fragment, use its contents otherwise return the child in an array
-	return child.nodeType === 11 ? Array.from(child.children) : [child];
+	return isDomFragment(child) ? Array.from(child.children) : [child];
 };
 
 /**

--- a/src/utils/internal.js
+++ b/src/utils/internal.js
@@ -30,6 +30,8 @@ export const isObject = (obj) => obj && typeof obj === 'object';
 
 export const createDocumentFragment = () => document.createDocumentFragment();
 
+export const isDomFragment = (node) => node && node.nodeType === 11;
+
 /**
  * @param {VNode} vnode
  * @param {boolean} recursive

--- a/src/utils/internal.js
+++ b/src/utils/internal.js
@@ -58,18 +58,6 @@ export const getVNodeFirstRenderedDom = (vnode) => {
 	return null;
 };
 
-/**
- * Returns an index of given element in its parent children list
- * @param {Element} child
- * @returns {number}
- */
-export const getIndexInParent = (child) => {
-	if (!child) undefined;
-	let index = 0;
-	while ((child = child.previousSibling) != null) index++;
-	return index;
-};
-
 // Internal object for storing details of current output/etc
 // This is just a placeholder object, all properties will be replaced to booleans with replace plugin.
 /**

--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -17,6 +17,7 @@ import {
 	getParent,
 	isObject,
 	domInsertBefore,
+	isDomFragment,
 } from './internal';
 
 /**
@@ -298,7 +299,7 @@ export const patchVnodeDom = (vnode, prevVnode, targetDomNode, afterNode) => {
 
 	// Get targeted domNode from the old rendered vnode.
 	// This also handles the case where Fragment or similar is a root of updated top level component
-	if (prevVnode) {
+	if ((!targetDomNode || isDomFragment(targetDomNode)) && prevVnode) {
 		const someDom = getVNodeFirstRenderedDom(prevVnode);
 		if (someDom) {
 			targetDomNode = getParent(someDom);
@@ -340,7 +341,7 @@ export const patchVnodeDom = (vnode, prevVnode, targetDomNode, afterNode) => {
 		const oldChildVnode = oldChildren && ((child && oldChildrenMap.get(child.key)) || oldChildren[index]);
 		const patchedDomNode = patchVnodeDom(child, (!child || isVnodeSame) && oldChildVnode, returnDom, prevNode);
 		if (isRenderableElement(patchedDomNode)) {
-			prevNode = patchedDomNode.nodeType === 11 ? patchedDomNode.lastChild : patchedDomNode;
+			prevNode = isDomFragment(patchedDomNode) ? patchedDomNode.lastChild : patchedDomNode;
 		}
 	}
 

--- a/test/js/jsx/jsx.spec.jsx
+++ b/test/js/jsx/jsx.spec.jsx
@@ -3,6 +3,7 @@ import { clearAll, unmount } from 'a-b-doer';
 import { useState, useEffect } from 'a-b-doer/hooks';
 import { Simple, RefHook, Hooks, Switch, OrderApp } from './templates';
 import { render } from './test-utils';
+import { patchVnodeDom, renderVnode } from '../../../src/utils/render';
 
 describe('JSX', () => {
 	vi.useFakeTimers();
@@ -29,7 +30,6 @@ describe('JSX', () => {
 	});
 
 	it('should pass props correctly', () => {
-		// 	await expect(t).toMatch(`"foo":"${tpl.indexOf(t)}"`);
 		const { vnode, element } = render(<Simple id="tpl1" foo="0" />);
 		expect(vnode.props).toMatchObject({ id: 'tpl1', foo: '0', children: [] });
 		expect(element).toContainHTML('"foo":"0"');
@@ -92,7 +92,7 @@ describe('JSX', () => {
 		expect(getByTestId('test-node').dataset.test).toBe('test-node');
 	});
 
-	it('should re-render elements in correct order', async () => {
+	it('should re-render elements in correct order', () => {
 		const { queryByTestId } = render(
 			<OrderApp>
 				<Simple class="simple-sub" id="tpl9-1" />
@@ -110,7 +110,7 @@ describe('JSX', () => {
 		}
 	});
 
-	it('should render conditional children correctly', async () => {
+	it('should render conditional children correctly', () => {
 		const App = ({ children }) => {
 			const [loading, setLoading] = useState(true);
 			useEffect(() => {
@@ -154,7 +154,7 @@ describe('JSX', () => {
 		}
 	});
 
-	it('should render correctly mapped array children', async () => {
+	it('should render correctly mapped array children', () => {
 		const { queryByTestId } = render(
 			<div data-test="container">
 				{[0, 1, 2].map((i) => (
@@ -176,7 +176,7 @@ describe('JSX', () => {
 		}
 	});
 
-	it('should render correctly mapped array children with fragments', async () => {
+	it('should render correctly mapped array children with fragments', () => {
 		const FragComponent = ({ children }) => (
 			<>
 				<>
@@ -213,5 +213,24 @@ describe('JSX', () => {
 		for (let i = 0; i < container.children.length - 1; i++) {
 			expect(container.children[i]).toBe(rows[i]);
 		}
+	});
+
+	it('should patch correctly if vnode type changes', () => {
+		const container = document.createElement('div');
+		const vnode = renderVnode(
+			<div>
+				<h1>Testing</h1>
+			</div>
+		);
+		patchVnodeDom(vnode, null, container);
+		expect(container.innerHTML).toBe('<div><h1>Testing</h1></div>');
+		const vnode2 = renderVnode(
+			<div>
+				<h4>Testing</h4>
+			</div>,
+			vnode
+		);
+		patchVnodeDom(vnode2, vnode, container);
+		expect(container.innerHTML).toBe('<div><h4>Testing</h4></div>');
 	});
 });

--- a/test/js/jsx/jsx.spec.jsx
+++ b/test/js/jsx/jsx.spec.jsx
@@ -153,4 +153,65 @@ describe('JSX', () => {
 			expect(children[i].innerHTML).toBe(`<h3>tpl test ${i + 1}</h3>`);
 		}
 	});
+
+	it('should render correctly mapped array children', async () => {
+		const { queryByTestId } = render(
+			<div data-test="container">
+				{[0, 1, 2].map((i) => (
+					<div key={`i${i}`} data-test="item" id={`item${i}`}>
+						Item {i}
+					</div>
+				))}
+				<div data-test="bottom-element">Bottom</div>
+			</div>
+		);
+
+		const container = queryByTestId('container');
+		expect(container.children.length).toBe(4);
+		const bottom = queryByTestId('bottom-element');
+		expect(container.lastChild).toBe(bottom);
+
+		for (let i = 0; i < container.children.length - 1; i++) {
+			expect(container.children[i].id).toBe(`item${i}`);
+		}
+	});
+
+	it('should render correctly mapped array children with fragments', async () => {
+		const FragComponent = ({ children }) => (
+			<>
+				<>
+					<div data-test="row">Some element</div>
+					<div data-test="row">{children}</div>
+				</>
+			</>
+		);
+
+		const FragComponent2 = ({ children }) => (
+			<>
+				<div data-test="subrow">Some other element</div>
+				<div data-test="subrow">{children}</div>
+			</>
+		);
+
+		const { queryByTestId, queryAllByTestId } = render(
+			<div data-test="container">
+				{[0, 1, 2].map((i) => (
+					<FragComponent key={`i${i}`}>
+						<FragComponent2>Item {i}</FragComponent2>
+					</FragComponent>
+				))}
+				<div data-test="bottom-element">Bottom</div>
+			</div>
+		);
+
+		const container = queryByTestId('container');
+		expect(container.children.length).toBe(7);
+		const bottom = queryByTestId('bottom-element');
+		expect(container.lastChild).toBe(bottom);
+		const rows = queryAllByTestId('row');
+
+		for (let i = 0; i < container.children.length - 1; i++) {
+			expect(container.children[i]).toBe(rows[i]);
+		}
+	});
 });


### PR DESCRIPTION
Fixes bugs from DOM patching for array typed children like
```jsx
<div>Foo</div>
{list.map(item => <SomeComponent key={item.id} />)}
<div>Bar</div>
```
Bug happened especially when there were Fragments either in map callback or as a root element for the custom component.

I also disabled CORS from puppeteer because it made loading of assets much slower because of preflight requests