### PR TITLE
fixed vite dev server filepath urls on windows

### DIFF
--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -400,7 +400,7 @@ export async function bundler(buildSpecConfig) {
 		//fix Windows specific filepaths
 		if (isWindows) {
 			// turns '\\' -> '/' and '//' -> '/' but not '://' into '/'
-			moduleScripts = [...moduleScripts.map((scriptUrl) => scriptUrl.replaceAll('\\','/').replaceAll(/(?<!:)\/\//g,'/'))];
+			moduleScripts = moduleScripts.map((scriptUrl) => scriptUrl.replaceAll('\\','/').replaceAll(/(?<!:)\/\//g,'/'));
 		}
 
 		const injection = `!(() => { \ndocument.head.append(${moduleScripts

--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -8,6 +8,7 @@ import browserslist from 'browserslist';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 import get from 'lodash.get';
 import stringHash from 'string-hash';
+import { platform } from 'os';
 import { fileURLToPath } from 'url';
 import { build, createServer } from 'vite';
 import prefresh from '@prefresh/vite';
@@ -383,7 +384,7 @@ export async function bundler(buildSpecConfig) {
 			console.log('');
 		}
 
-		const moduleScripts = [
+		let moduleScripts = [
 			`https://localhost:${port}/@vite/client`,
 			`https://localhost:${port}${entryFile.replace(cwd, '')}`,
 		];
@@ -392,6 +393,14 @@ export async function bundler(buildSpecConfig) {
 			moduleScripts.push(
 				`https://localhost:${port}/${path.join(rootDir.replace(cwd, ''), 'dist', 'lib', 'pptr-toolbar.js')}`
 			);
+		}
+
+
+		const isWindows = platform() == 'win32';
+		//fix Windows specific filepaths
+		if (isWindows) {
+			// turns '\\' -> '/' and '//' -> '/' but not '://' into '/'
+			moduleScripts = [...moduleScripts.map((scriptUrl) => {scriptUrl.replaceAll('\\','/').replaceAll(/(?<!:)\/\//g,'/')})]
 		}
 
 		const injection = `!(() => { \ndocument.head.append(${moduleScripts

--- a/lib/bundler.js
+++ b/lib/bundler.js
@@ -400,7 +400,7 @@ export async function bundler(buildSpecConfig) {
 		//fix Windows specific filepaths
 		if (isWindows) {
 			// turns '\\' -> '/' and '//' -> '/' but not '://' into '/'
-			moduleScripts = [...moduleScripts.map((scriptUrl) => {scriptUrl.replaceAll('\\','/').replaceAll(/(?<!:)\/\//g,'/')})]
+			moduleScripts = [...moduleScripts.map((scriptUrl) => scriptUrl.replaceAll('\\','/').replaceAll(/(?<!:)\/\//g,'/'))];
 		}
 
 		const injection = `!(() => { \ndocument.head.append(${moduleScripts


### PR DESCRIPTION
On Windows machines moduleScript filepaths received windows specific filepaths, e.g '\\node_modules\\somecooldep'. Now backslashes (\\) are replaced by forward slashes (/).